### PR TITLE
ref(start-node): make /bin/start-node an entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,4 +91,5 @@ ENV PATH=$JENKINS_HOME/bin:/usr/local/go/bin:$PATH
 
 WORKDIR $JENKINS_HOME
 
-CMD ["start-node"]
+ENTRYPOINT ["/bin/start-node"]
+CMD ["jenkins"]

--- a/rootfs/bin/start-node
+++ b/rootfs/bin/start-node
@@ -11,12 +11,15 @@ else
     addgroup jenkins "$(stat -c "%G" /var/run/docker.sock)"
 fi
 
-wget -N https://ci.deis.io/jnlpJars/slave.jar
-
 # chown any mounted volumes to the jenkins owner
 chown -R jenkins:jenkins $JENKINS_HOME
 
-# NOTE(bacongobbler): sudo overwrites PATH even with -E specified. A workaround is to use
-# `env "PATH=$PATH"`.
-# See http://superuser.com/questions/98686/passing-path-through-sudo
-exec sudo -E -u jenkins env "PATH=$PATH" java -jar slave.jar -jnlpUrl https://ci.deis.io/computer/${NODE_NAME?}/slave-agent.jnlp -secret ${NODE_SECRET?}
+if [ "$1" = 'jenkins' ]; then
+    wget -N https://ci.deis.io/jnlpJars/slave.jar
+    # NOTE(bacongobbler): sudo overwrites PATH even with -E specified. A workaround is to use
+    # `env "PATH=$PATH"`.
+    # See http://superuser.com/questions/98686/passing-path-through-sudo
+    exec sudo -E -u jenkins env "PATH=$PATH" java -jar slave.jar -jnlpUrl https://ci.deis.io/computer/${NODE_NAME?}/slave-agent.jnlp -secret ${NODE_SECRET?}
+fi
+
+exec sudo -E -u jenkins env "PATH=$PATH" "$@"


### PR DESCRIPTION
This way all commands will be run under the jenkins user and will be guaranteed to have the correct
write permissions to the docker socket and $JENKINS_HOME.

cc @vdice 