### PR TITLE
chore(Dockerfile): bump go to v1.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN git config --global user.email "ci@deis.com"
 RUN git config --global user.name 'Deis CI'
 
 # install go 1.7.5
-ENV GO_VERSION=1.7.5
+ENV GO_VERSION=1.8.3
 RUN curl -L https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xz
 
 RUN mkdir -p $JENKINS_HOME/go/src


### PR DESCRIPTION
This is blocking CI for Azure/draft#244 as we now rely on certain Go 1.8 features in pkg net/http.