### PR TITLE
chore(Dockerfile): bump remoting to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk
 
-ARG JENKINS_REMOTING_VERSION=3.7
+ARG JENKINS_REMOTING_VERSION=3.10
 
 RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${JENKINS_REMOTING_VERSION}/remoting-${JENKINS_REMOTING_VERSION}.jar \
   && chmod 755 /usr/share/jenkins \


### PR DESCRIPTION
For some unexplained reason, v0.4.1 is able to deploy just fine on master, but v0.4.2 is not:

```
leeroyuser@k8s-master-32846151-0:~$ kubectl -n jenkins logs default-jenkins-agent-g3jjj
Option g is ambiguous (gecos, gid, group)
adduser [--home DIR] [--shell SHELL] [--no-create-home] [--uid ID]
[--firstuid ID] [--lastuid ID] [--gecos GECOS] [--ingroup GROUP | --gid ID]
[--disabled-password] [--disabled-login] [--add_extra_groups] USER
   Add a normal user
adduser --system [--home DIR] [--shell SHELL] [--no-create-home] [--uid ID]
[--gecos GECOS] [--group | --ingroup GROUP | --gid ID] [--disabled-password]
[--disabled-login] [--add_extra_groups] USER
   Add a system user
adduser --group [--gid ID] GROUP
addgroup [--gid ID] GROUP
   Add a user group
addgroup --system [--gid ID] GROUP
   Add a system group
adduser USER GROUP
   Add an existing user to an existing group
general options:
  --quiet | -q      don't give process information to stdout
  --force-badname   allow usernames which do not match the
                    NAME_REGEX configuration variable
  --help | -h       usage message
  --version | -v    version number and copyright
  --conf | -c FILE  use FILE as configuration file
Adding user `jenkins' to group `jenkins' ...
Adding user jenkins to group jenkins
Done.
Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior
Error: Could not find or load main class
```

In an attempt to fix this, perhaps bumping the remoting version up to v3.10 (latest) may resolve this issue.