### PR TITLE
fix(jenkins-slave): fix jenkins-slave exec script

### DIFF
--- a/rootfs/usr/local/bin/jenkins-slave
+++ b/rootfs/usr/local/bin/jenkins-slave
@@ -31,9 +31,9 @@
 
 # HACK(bacongobbler): allow jenkins user group permission to Docker socket
 if addgroup -g "$(stat -c "%g" /var/run/docker.sock)" docker; then
-		addgroup jenkins docker
+	addgroup jenkins docker
 else
-		addgroup jenkins "$(stat -c "%G" /var/run/docker.sock)"
+	addgroup jenkins "$(stat -c "%G" /var/run/docker.sock)"
 fi
 
 # chown any mounted volumes to the jenkins owner
@@ -66,7 +66,29 @@ else
 		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
 	fi
 
+	# If both required options are defined, do not pass the parameters
+	OPT_JENKINS_SECRET=""
+	if [ -n "$JENKINS_SECRET" ]; then
+		if [[ "$@" != *"${JENKINS_SECRET}"* ]]; then
+			OPT_JENKINS_SECRET="${JENKINS_SECRET}"
+		else
+			echo "Warning: SECRET is defined twice in command-line arguments and the environment variable"
+		fi
+	fi
+
+	OPT_JENKINS_AGENT_NAME=""
+	if [ -n "$JENKINS_AGENT_NAME" ]; then
+		if [[ "$@" != *"${JENKINS_AGENT_NAME}"* ]]; then
+			OPT_JENKINS_AGENT_NAME="${JENKINS_AGENT_NAME}"
+		else
+			echo "Warning: AGENT_NAME is defined twice in command-line arguments and the environment variable"
+		fi
+	fi
+
+	#TODO: Handle the case when the command-line and Environment variable contain different values.
+	#It is fine it blows up for now since it should lead to an error anyway.
+
 	exec sudo -E -u jenkins env "PATH=$PATH" \
-		java "$JAVA_OPTS" "$JNLP_PROTOCOL_OPTS" -cp /usr/share/jenkins/slave.jar \
-		hudson.remoting.jnlp.Main -headless "$TUNNEL" "$URL" "$JENKINS_SECRET" "$JENKINS_AGENT_NAME" "$@"
+		java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar \
+		hudson.remoting.jnlp.Main -headless $TUNNEL $URL $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi

--- a/rootfs/usr/local/bin/jenkins-slave
+++ b/rootfs/usr/local/bin/jenkins-slave
@@ -69,7 +69,7 @@ else
 	# If both required options are defined, do not pass the parameters
 	OPT_JENKINS_SECRET=""
 	if [ -n "$JENKINS_SECRET" ]; then
-		if [[ "$@" != *"${JENKINS_SECRET}"* ]]; then
+		if [[ "$*" != *"${JENKINS_SECRET}"* ]]; then
 			OPT_JENKINS_SECRET="${JENKINS_SECRET}"
 		else
 			echo "Warning: SECRET is defined twice in command-line arguments and the environment variable"
@@ -78,7 +78,7 @@ else
 
 	OPT_JENKINS_AGENT_NAME=""
 	if [ -n "$JENKINS_AGENT_NAME" ]; then
-		if [[ "$@" != *"${JENKINS_AGENT_NAME}"* ]]; then
+		if [[ "$*" != *"${JENKINS_AGENT_NAME}"* ]]; then
 			OPT_JENKINS_AGENT_NAME="${JENKINS_AGENT_NAME}"
 		else
 			echo "Warning: AGENT_NAME is defined twice in command-line arguments and the environment variable"
@@ -87,8 +87,7 @@ else
 
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
-
+	# shellcheck disable=SC2086
 	exec sudo -E -u jenkins env "PATH=$PATH" \
-		java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar \
-		hudson.remoting.jnlp.Main -headless $TUNNEL $URL $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+		java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi


### PR DESCRIPTION
This brings the script up to date with what's in jenkinsci/docker-jnlp-slave. I tested this script in a production cluster:

    + exec java -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless -tunnel jenkins-jenkins-jnlp:50000 -url http://jenkins-jenkins:8080 [REDACTED] default-jenkins-agent-w9tjc
    Aug 11, 2017 9:17:17 PM hudson.remoting.jnlp.Main createEngine
    ...

As opposed to our existing script, which will fail out (notice the quoting around certain arguments:

    + exec sudo -E -u jenkins env PATH=/home/jenkins/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin java '' -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless '-tunnel jenkins-jenkins-jnlp:50000' '-url http://jenkins-jenkins:8080' [REDACTED] default-jenkins-agent-w9tjc
    Error: Could not find or load main class

See https://github.com/jenkinsci/docker-jnlp-slave/blob/master/jenkins-slave for more info.